### PR TITLE
added a generic overload of RenderComponentAs

### DIFF
--- a/GridBlazor/Columns/GridColumnBase.cs
+++ b/GridBlazor/Columns/GridColumnBase.cs
@@ -94,6 +94,13 @@ namespace GridBlazor.Columns
             return this;
         }
 
+        public IGridColumn<T> RenderComponentAs<TComponent>()
+             where TComponent : ICustomGridComponent<T>
+        {
+            ComponentType = typeof(TComponent);
+            return this;
+        }
+
         public IGridColumn<T> Format(string pattern)
         {
             ValuePattern = pattern;

--- a/GridMvc/Columns/GridColumnBase.cs
+++ b/GridMvc/Columns/GridColumnBase.cs
@@ -100,6 +100,13 @@ namespace GridMvc.Columns
             return this;
         }
 
+        public IGridColumn<T> RenderComponentAs<TComponent>()
+            where TComponent : ICustomGridComponent<T>
+        {
+            // do nothing
+            return this;
+        }
+
         public IGridColumn<T> Format(string pattern)
         {
             ValuePattern = pattern;

--- a/GridShared/Columns/ICustomGridComponent.cs
+++ b/GridShared/Columns/ICustomGridComponent.cs
@@ -1,0 +1,7 @@
+﻿namespace GridShared.Columns
+{
+    public interface ICustomGridComponent<T>
+    {
+        T Item { get; }
+    }
+}

--- a/GridShared/Columns/IGridColumn.cs
+++ b/GridShared/Columns/IGridColumn.cs
@@ -73,6 +73,11 @@ namespace GridShared.Columns
         IGridColumn<T> RenderComponentAs(Type componentType);
 
         /// <summary>
+        ///     Setup the custom render for component
+        /// </summary>
+        IGridColumn<T> RenderComponentAs<TComponent>() where TComponent : ICustomGridComponent<T>;
+
+        /// <summary>
         ///     Format column values with specified text pattern
         /// </summary>
         IGridColumn<T> Format(string pattern);


### PR DESCRIPTION
This would add some compile-time safety about the `Item` property. However, it forces the implementer to make the `Item` property public. Personally, I could live with that. Just an idea.