### PR TITLE
Added HasConstraint property to GridColumnBase

### DIFF
--- a/GridBlazor/Columns/GridColumn.cs
+++ b/GridBlazor/Columns/GridColumn.cs
@@ -1,4 +1,4 @@
-﻿using GridShared;
+using GridShared;
 using GridShared.Columns;
 using GridShared.Filtering;
 using GridShared.Grouping;
@@ -116,6 +116,8 @@ namespace GridBlazor.Columns
         {
             get { return _grid; }
         }
+
+        public override bool HasConstraint => _constraint != null;
 
         public override IGridColumn<T> SetFilterWidgetType(string typeName, object widgetData)
         {

--- a/GridBlazor/Columns/GridColumnBase.cs
+++ b/GridBlazor/Columns/GridColumnBase.cs
@@ -1,4 +1,4 @@
-﻿using GridShared;
+using GridShared;
 using GridShared.Columns;
 using GridShared.Filtering;
 using GridShared.Grouping;
@@ -13,14 +13,14 @@ using System.Linq.Expressions;
 
 namespace GridBlazor.Columns
 {
-    public abstract class GridColumnBase<T> : GridStyledColumn, IGridColumn<T>, ICGridColumn
+    public abstract class GridColumnBase<T> : GridStyledColumn, IGridColumn<T>, ICGridColumn, IConstrainedGridColumn
     {
         public Type ComponentType { get; private set; }
         public IList<Action<object>> Actions { get; private set; }
         public object Object { get; private set; }
 
-        protected Func<T, string> ValueConstraint;
-        protected string ValuePattern;
+        public Func<T, string> ValueConstraint { get; private set; }
+        public string ValuePattern { get; private set; }
 
         #region IGridColumn<T> Members
 
@@ -235,5 +235,12 @@ namespace GridBlazor.Columns
         public abstract IGridCell GetValue(T instance);
 
         #endregion
+
+        #region IConstrainedGridColumn Members
+
+        public abstract bool HasConstraint { get; }
+
+        #endregion
+
     }
 }

--- a/GridBlazor/Columns/HiddenGridColumn.cs
+++ b/GridBlazor/Columns/HiddenGridColumn.cs
@@ -1,4 +1,4 @@
-﻿using GridShared;
+using GridShared;
 using GridShared.Columns;
 using GridShared.Filtering;
 using GridShared.Grouping;
@@ -11,9 +11,6 @@ using System.Linq.Expressions;
 
 namespace GridBlazor.Columns
 {
-    /// <summary>
-    ///     Колонка, которая выводит содержимое свойства модели
-    /// </summary>
     public class HiddenGridColumn<T, TDataType> : GridColumnBase<T>
     {
         private readonly Func<T, TDataType> _constraint;
@@ -108,6 +105,8 @@ namespace GridBlazor.Columns
         {
             return this; //Do nothing
         }
+
+        public override bool HasConstraint => _constraint != null;
 
         public override IGridCell GetValue(T instance)
         {

--- a/GridBlazor/Columns/IConstrainedGridColumn.cs
+++ b/GridBlazor/Columns/IConstrainedGridColumn.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GridBlazor.Columns
+{
+    interface IConstrainedGridColumn
+    {
+        bool HasConstraint { get; }
+    }
+
+    interface IConstrainedGridColumn<T, TDataType> : IConstrainedGridColumn
+    {
+        Func<T, TDataType> Constraint { get; }
+    }
+}


### PR DESCRIPTION
`GridColumn.GetValue()` throws an exception if `_constraint == null`. That is fine, however, when calling from outside, there is no way to know whether `GridColumn.GetValue()` would throw an exception or not. With this changes, it becomes possible to do things like:
`string value = gridColumn.HasConstraint ? gridColumn.GetValue(item).Value : "";`