### PR TITLE
Changed page navigation to require Ctrl qualifier.

### DIFF
--- a/GridBlazor/Pages/GridComponent.razor.cs
+++ b/GridBlazor/Pages/GridComponent.razor.cs
@@ -488,11 +488,11 @@ namespace GridBlazor.Pages
 
         public async Task GridComponentKeyup(KeyboardEventArgs e)
         {
-            if (e.Key == "ArrowLeft" && Grid.Pager.CurrentPage > 1)
+            if (e.CtrlKey && e.Key == "ArrowLeft" && Grid.Pager.CurrentPage > 1)
             {
                 await GoTo(Grid.Pager.CurrentPage - 1);
             }
-            else if (e.Key == "ArrowRight" && Grid.Pager.CurrentPage < ((GridPager)Grid.Pager).PageCount)
+            else if (e.CtrlKey && e.Key == "ArrowRight" && Grid.Pager.CurrentPage < ((GridPager)Grid.Pager).PageCount)
             {
                 await GoTo(Grid.Pager.CurrentPage + 1);
             }

--- a/GridBlazor/Pages/GridComponent.razor.cs
+++ b/GridBlazor/Pages/GridComponent.razor.cs
@@ -496,11 +496,11 @@ namespace GridBlazor.Pages
             {
                 await GoTo(Grid.Pager.CurrentPage + 1);
             }
-            else if (e.Key == "Home")
+            else if (e.CtrlKey && e.Key == "Home")
             {
                 await GoTo(1);
             }
-            else if (e.Key == "End")
+            else if (e.CtrlKey && e.Key == "End")
             {
                 await GoTo(((GridPager)Grid.Pager).PageCount);
             }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Grid.Blazor
 
-A fork from: https://github.com/gustavnavar/Grid.Blazor (is forked from  https://gridmvc.codeplex.com/)
+A fork from: https://gridmvc.codeplex.com/
 
 It supports .NET Core 3.1
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Grid.Blazor
 
-A fork from: https://gridmvc.codeplex.com/
+A fork from: https://github.com/gustavnavar/Grid.Blazor (is forked from  https://gridmvc.codeplex.com/)
 
 It supports .NET Core 3.1
 

--- a/docs/blazor_client/Keyboard_navigation.md
+++ b/docs/blazor_client/Keyboard_navigation.md
@@ -8,9 +8,9 @@ Users can navigate between pages using the mouse or using the keyboard.
 
 These are the keys to be used:
 
-- [Left] and [Right] arrows navigate between pages
-- [Home] key goes to the first page
-- [End] key goes to the last page
+- [Ctrl] + [Left] and [Ctrl] + [Right] arrows navigate between pages
+- [Ctrl] + [Home] key goes to the first page
+- [Ctrl] + [End] key goes to the last page
 - [Up] and [Down] arrows navigate from one row to another for grids where rows are selectable
 - [Tab] key navigates among elements of a filter widget when it is visible
 - [Esc] key minimises a filter widget when it is visible

--- a/docs/blazor_server/Keyboard_navigation.md
+++ b/docs/blazor_server/Keyboard_navigation.md
@@ -8,9 +8,9 @@ Users can navigate between pages using the mouse or using the keyboard.
 
 These are the keys to be used:
 
-- [Left] and [Right] arrows navigate between pages
-- [Home] key goes to the first page
-- [End] key goes to the last page
+- [Ctrl] + [Left] and [Ctrl] + [Right] arrows navigate between pages
+- [Ctrl] + [Home] key goes to the first page
+- [Ctrl] + [End] key goes to the last page
 - [Up] and [Down] arrows navigate from one row to another for grids where rows are selectable
 - [Tab] key navigates among elements of a filter widget when it is visible
 - [Esc] key minimises a filter widget when it is visible


### PR DESCRIPTION
Changed page navigation from Left/Right Arrow keys to Ctrl + Left/Right arrow keys and Home and End keys to Ctrl + home and Ctrl + end key. This is introduced to avoid conflict between page scroll using keyboard and page navigation. 