### PR TITLE
Added type="button" to all <button> with no specified type 

### DIFF
--- a/GridBlazor/Pages/GridDeleteComponent.razor
+++ b/GridBlazor/Pages/GridDeleteComponent.razor
@@ -40,7 +40,7 @@
     <div class="form-group row">
         <div class="col-md-5">
             <button type="submit" class="btn btn-primary btn-md" @onclick="DeleteItem">@Strings.Delete</button>
-            <button class="btn btn-primary btn-md" @onclick="BackButtonClicked">@Strings.Back</button>
+            <button type="button" class="btn btn-primary btn-md" @onclick="BackButtonClicked">@Strings.Back</button>
         </div>
     </div>
 </div>

--- a/GridBlazor/Pages/GridExtSortHeaderComponent.razor
+++ b/GridBlazor/Pages/GridExtSortHeaderComponent.razor
@@ -27,10 +27,10 @@
             }
             <span class="grid-extsort-column" data-name="@column.ColumnName" data-extsortdata="@GridShared.Utility.JsonHelper.JsonSerializer(column)">
                 <span class="@(column.Direction == GridSortDirection.Ascending ? "sorted-asc" : "sorted-desc")">
-                    <button class="btn btn-link" @onclick="() => TitleButtonClicked(column)" data-column="@column.ColumnName">@gridColumn.Title</button>
+                    <button type="button" class="btn btn-link" @onclick="() => TitleButtonClicked(column)" data-column="@column.ColumnName">@gridColumn.Title</button>
                     <span class="grid-sort-arrow"></span>
                 </span>
-                <button class="btn btn-link" @onclick="() => CancelButtonClicked(column)" data-column="@column.ColumnName">x</button>
+                <button type="button" class="btn btn-link" @onclick="() => CancelButtonClicked(column)" data-column="@column.ColumnName">x</button>
             </span>
         }
     }

--- a/GridBlazor/Pages/GridHeaderComponent.razor
+++ b/GridBlazor/Pages/GridHeaderComponent.razor
@@ -43,7 +43,7 @@
         <div class="@_cssSortingClass">
             @if (Column.SortEnabled)
             {
-                <button @onclick="TitleButtonClicked">@Column.Title</button>
+                <button @onclick="TitleButtonClicked" type="button">@Column.Title</button>
             }
             else
             {

--- a/GridBlazor/Pages/GridPagerComponent.razor
+++ b/GridBlazor/Pages/GridPagerComponent.razor
@@ -7,18 +7,18 @@
             @if (GridPager.CurrentPage > 1)
             {
                 <li class="page-item">
-                    <button class="page-link" @onclick="() => PagerButtonClicked(GridPager.CurrentPage - 1)">«</button>
+                    <button type="button" class="page-link" @onclick="() => PagerButtonClicked(GridPager.CurrentPage - 1)">«</button>
                 </li>
             }
             @if (GridPager.StartDisplayedPage > 1)
             {
                 <li class="page-item">
-                    <button class="page-link" @onclick="() => PagerButtonClicked(1)">1</button>
+                    <button type="button" class="page-link" @onclick="() => PagerButtonClicked(1)">1</button>
                 </li>
                 @if (GridPager.StartDisplayedPage > 2)
                 {
                     <li class="page-item">
-                        <button class="page-link" @onclick="() => PagerButtonClicked(GridPager.StartDisplayedPage - 1)">...</button>
+                        <button type="button" class="page-link" @onclick="() => PagerButtonClicked(GridPager.StartDisplayedPage - 1)">...</button>
                     </li>
                 }
             }
@@ -27,14 +27,14 @@
                 if (i == GridPager.CurrentPage)
                 {
                     <li class="page-item active">
-                        <button class="page-link">@i <span class="sr-only">(current)</span></button>
+                        <button type="button" class="page-link">@i <span class="sr-only">(current)</span></button>
                     </li>
                 }
                 else
                 {
                     int j = i;
                     <li class="page-item">
-                        <button class="page-link" @onclick="async () => await PagerButtonClicked(j)">@j</button>
+                        <button type="button" class="page-link" @onclick="async () => await PagerButtonClicked(j)">@j</button>
                     </li>
                 }
             }
@@ -43,17 +43,17 @@
                 if (GridPager.EndDisplayedPage < GridPager.PageCount - 1)
                 {
                     <li class="page-item">
-                        <button class="page-link" @onclick="async () => await PagerButtonClicked(GridPager.EndDisplayedPage + 1)">...</button>
+                        <button type="button" class="page-link" @onclick="async () => await PagerButtonClicked(GridPager.EndDisplayedPage + 1)">...</button>
                     </li>
                 }
                 <li class="page-item">
-                    <button class="page-link" @onclick="async () => await PagerButtonClicked(GridPager.PageCount)">@GridPager.PageCount</button>
+                    <button type="button" class="page-link" @onclick="async () => await PagerButtonClicked(GridPager.PageCount)">@GridPager.PageCount</button>
                 </li>
             }
             @if (GridPager.CurrentPage < GridPager.PageCount)
             {
                 <li class="page-item">
-                    <button class="page-link" @onclick="async () => await PagerButtonClicked(GridPager.CurrentPage + 1)">»</button>
+                    <button type="button" class="page-link" @onclick="async () => await PagerButtonClicked(GridPager.CurrentPage + 1)">»</button>
                 </li>
             }
         </ul>

--- a/GridBlazor/Pages/GridReadComponent.razor
+++ b/GridBlazor/Pages/GridReadComponent.razor
@@ -39,7 +39,7 @@
 
     <div class="form-group row">
         <div class="col-md-5">
-            <button class="btn btn-primary btn-md" @onclick="BackButtonClicked">@Strings.Back</button>
+            <button type="button" class="btn btn-primary btn-md" @onclick="BackButtonClicked">@Strings.Back</button>
         </div>
     </div>
 </div>

--- a/GridBlazorClientSide.Client/Shared/NavMenu.razor
+++ b/GridBlazorClientSide.Client/Shared/NavMenu.razor
@@ -1,6 +1,6 @@
 ﻿<div class="top-row pl-4 navbar navbar-dark">
     <a class="navbar-brand" href="">GridBlazor</a>
-    <button class="navbar-toggler" @onclick="ToggleNavMenu">
+    <button type="button" class="navbar-toggler" @onclick="ToggleNavMenu">
         <span class="navbar-toggler-icon"></span>
     </button>
 </div>

--- a/GridBlazorServerSide/Shared/NavMenu.razor
+++ b/GridBlazorServerSide/Shared/NavMenu.razor
@@ -1,6 +1,6 @@
 ﻿<div class="top-row pl-4 navbar navbar-dark">
     <a class="navbar-brand" href="">GridBlazor</a>
-    <button class="navbar-toggler" @onclick="ToggleNavMenu">
+    <button type="button" class="navbar-toggler" @onclick="ToggleNavMenu">
         <span class="navbar-toggler-icon"></span>
     </button>
 </div>


### PR DESCRIPTION
A lot of `<button>` elements had no `type` specified. As a result, if the grid was within a `<form>`, those buttons would cause the form to submit instead (defaults to `type="submit"`). Not what you expect when you click on a table column :)