### PR TITLE
Correct parameter assignation to Crud

### DIFF
--- a/GridBlazor/Client/GridClient.cs
+++ b/GridBlazor/Client/GridClient.cs
@@ -215,7 +215,7 @@ namespace GridBlazor
             _source.CreateEnabled = createEnabled;
             _source.ReadEnabled = readEnabled;
             _source.UpdateEnabled = updateEnabled;
-            _source.DeleteEnabled = updateEnabled;
+            _source.DeleteEnabled = deleteEnabled;
             _source.CrudDataService = crudDataService;
             return this;
         }


### PR DESCRIPTION
The deleteEnabled parameter is not assigned and the updateEnabled is assigned twice in the following.
Assign the parameter deleteEnabled to _source.DeleteEnabled.