### PR TITLE
Set Id of the new ColumnOrderValue to the max Id plus 1

### DIFF
--- a/GridBlazor/Pages/GridHeaderComponent.razor.cs
+++ b/GridBlazor/Pages/GridHeaderComponent.razor.cs
@@ -170,8 +170,9 @@ namespace GridBlazor.Pages
 
         protected void HandleDragStart()
         {
-            GridComponent.Payload = new ColumnOrderValue(Column.Name, Column.Direction ?? GridSortDirection.Ascending,
-                GridComponent.Grid.Settings.SortSettings.SortValues.Count + 1);
+            var values = GridComponent.Grid.Settings.SortSettings.SortValues;
+            var maxId = values.Any() ? values.Max(x => x.Id) + 1 : 1;
+            GridComponent.Payload = new ColumnOrderValue(Column.Name, Column.Direction ?? GridSortDirection.Ascending, maxId);
         }
     }
 }


### PR DESCRIPTION
Currently the code takes the number of sort elements plus 1. Nevertheless if I select two columns to sort by, then delete the first, and add anew one, both will have Id = 2.
The sugested change checks the List of SortValues and gets the maximum Id Value, and adds 1