### PR TITLE
Allow ICustomGridComponent<> type argument to be interface of Grid data type

### DIFF
--- a/GridBlazor/Columns/GridColumnBase.cs
+++ b/GridBlazor/Columns/GridColumnBase.cs
@@ -149,8 +149,15 @@ namespace GridBlazor.Columns
         public IGridColumn<T> RenderComponentAs(Type componentType, IList<Action<object>> actions,
             IList<Func<object, Task>> functions, object obj)
         {
-            if (componentType.GetInterfaces().Any(r => r.Equals(typeof(ICustomGridComponent<T>)))
-                && componentType.IsSubclassOf(typeof(ComponentBase)))
+            /// Get type arguments from any <see cref="ICustomGridComponent<>"/> interface 
+            /// in <paramref name="componentType"/> to make sure <see cref="T"/> is assignable to it
+            List<Type> typeArgs = (from iType in componentType.GetInterfaces()
+                                   where iType.IsGenericType && 
+                                   iType.GetGenericTypeDefinition() == typeof(ICustomGridComponent<>)
+                                   select iType.GetGenericArguments()[0]).ToList();
+            
+            if (typeArgs.Any(t => t.IsAssignableFrom(typeof(T))) &&
+                componentType.IsSubclassOf(typeof(ComponentBase)))
             {
                 ComponentType = componentType;
                 Actions = actions;


### PR DESCRIPTION
Fixes #53 

My grid uses type Person. Person class implements IDataModel. I want my component to be able to be implemented like example below with `ICustomGridComponent<IDataModel>`. This PR fixes that.
Example:
```csharp
@using GridBlazor
@using GridShared.Columns
@implements ICustomGridComponent<IDataModel>
@inject NavigationManager navigationManager

<button class='btn btn-sm btn-primary' @onclick="MyClickHandler">Edit</button>

@code {
    [Parameter]
    public IDataModel Item { get; set; }

    private void MyClickHandler(MouseEventArgs e)
    {
        navigationManager.NavigateTo($"/editorder/{ Item.Id.ToString() }");
    }
}
```