### PR TITLE
Fix search and filter GetExpression for Linq on objects (nested properties)

### DIFF
--- a/GridShared/Searching/DefaultColumnSearch.cs
+++ b/GridShared/Searching/DefaultColumnSearch.cs
@@ -40,38 +40,41 @@ namespace GridShared.Searching
                 //get target type:
                 Type targetType = isNullable ? Nullable.GetUnderlyingType(pi.PropertyType) : pi.PropertyType;
 
+                // bool columns are not searched as a workaround until the final release of EF Core 3.0
+                if (targetType == typeof(bool)) return null;
+
                 if (onlyTextColumns && targetType != typeof(string))
                     return null;
 
                 //get first expression
                 Expression firstExpression = parameter;
+                Expression binaryExpression = null;
                 for (int i = names.Count - 1; i >= 0; i--)
                 {
                     firstExpression = Expression.Property(firstExpression, names[i]);
-                }
-                Expression binaryExpression = null;
 
-                // bool columns are not searched as a workaround until the final release of EF Core 3.0
-                if (targetType == typeof(bool))
-                {
-                    return null;
+                    // Check for null on nested properties and target object if it's a string
+                    // It's ok for ORM, but throw exception in linq to objects
+                    if (i > 0 || (i == 0 && targetType == typeof(string)))
+                    {
+                        binaryExpression = binaryExpression == null ?
+                            Expression.NotEqual(firstExpression, Expression.Constant(null)) :
+                            Expression.AndAlso(binaryExpression, Expression.NotEqual(firstExpression, Expression.Constant(null)));
+                    }
                 }
-                if (targetType == typeof(string))
-                {
-                    //check for strings, they may be NULL
-                    //It's ok for ORM, but throw exception in linq to objects. Additional check string on null
-                    binaryExpression = Expression.NotEqual(firstExpression, Expression.Constant(null));
-                }
-                else
+                
+                if (targetType != typeof(string))
                 {
                     if (isNullable)
                     {
                         //add additional filter condition for check items on NULL with invoring "HasValue" method.
                         //for example: result of this expression will like - c=> c.HasValue && c.Value = 3
-                        binaryExpression = Expression.Property(firstExpression,
-                                                                            pi.PropertyType.GetProperty("HasValue"));
-                        firstExpression = Expression.Property(firstExpression,
-                                                                            pi.PropertyType.GetProperty("Value"));
+                        if (binaryExpression == null)
+                            binaryExpression = Expression.Property(firstExpression, pi.PropertyType.GetProperty("HasValue"));
+                        else
+                            binaryExpression = Expression.AndAlso(binaryExpression, Expression.Property(firstExpression, pi.PropertyType.GetProperty("HasValue")));
+
+                        firstExpression = Expression.Property(firstExpression, pi.PropertyType.GetProperty("Value"));
                     }
                     // add ToString method to non string columns
                     MethodInfo toString = targetType.GetMethod("ToString", Type.EmptyTypes);


### PR DESCRIPTION
Fixes #93 

It turns out the issue is because of null on nested properties.
When `Owner_person` is null here: `x.Owner_person.full_name` is when the exception occurred.

I don't know if this is the proper fix but it seems to work great like this, and I think everything else should continue to work as normal.