### PR TITLE
Code improvement suggestion to make it possible to hide columns on the fly

### DIFF
--- a/GridBlazor/Pages/GridComponent.razor.cs
+++ b/GridBlazor/Pages/GridComponent.razor.cs
@@ -843,9 +843,9 @@ namespace GridBlazor.Pages
             }
         }
 
-        public async Task UpdateGrid()
+        public async Task UpdateGrid(bool ReloadData = true)
         {
-            await Grid.UpdateGrid();
+            if (ReloadData) await Grid.UpdateGrid();
             SelectedRow = -1;
             SelectedRows.Clear();
             InitSubGridVars();

--- a/GridShared/Columns/GridStyledColumn.cs
+++ b/GridShared/Columns/GridStyledColumn.cs
@@ -28,5 +28,17 @@ namespace GridShared.Columns
             if (!_styles.Contains(styleString))
                 _styles.Add(styleString);
         }
+
+        public void RemoveCssClass(string className)
+        {
+            if (_classes.Contains(className))
+                _classes.Remove(className);
+        }
+
+        public void RemoveCssStyle(string styleString)
+        {
+            if (_styles.Contains(styleString))
+                _styles.Remove(styleString);
+        }
     }
 }


### PR DESCRIPTION
Fixes #99
With the added code, this would be possible:

**Hide column**
```csharp
var col = (GridColumnBase<Driver>)componentDriver.Grid.Columns.Where(c => c.Title == "ID hide").First();
col.AddCssStyle("display:none;");
componentDriver?.UpdateGrid(false);
```

**Show column**
```csharp
var col = (GridColumnBase<Driver>)componentDriver.Grid.Columns.Where(c => c.Title == "ID hide").First();
col.RemoveCssStyle("display:none;");
componentDriver?.UpdateGrid(false);
```