### PR TITLE
Add filter support for enum properties

### DIFF
--- a/GridBlazor.Tests/Filtering/FilterTests.cs
+++ b/GridBlazor.Tests/Filtering/FilterTests.cs
@@ -241,6 +241,30 @@ namespace GridBlazor.Tests.Filtering
         }
 
         [TestMethod]
+        public void TestEnumFilteringEquals()
+        {
+            var filterOption = new ColumnFilterValue
+            {
+                ColumnName = "EnumField",
+                FilterType = GridFilterType.Equals,
+                FilterValue = "Foo"
+            };
+            var filterOptions = new List<ColumnFilterValue>();
+            filterOptions.Add(filterOption);
+            var filter = new DefaultColumnFilter<TestModel, TestEnum>(m => m.EnumField);
+
+            var filtered = filter.ApplyFilter(_repo.GetAll().AsQueryable(), filterOptions);
+
+            var original = _repo.GetAll().AsQueryable().Where(t => t.EnumField == TestEnum.Foo);
+
+            for (int i = 0; i < filtered.Count(); i++)
+            {
+                if (filtered.ElementAt(i).Id != original.ElementAt(i).Id)
+                    Assert.Fail("Filtering not works");
+            }
+        }
+
+        [TestMethod]
         public void TestGuidFilterContains()
         {
             var filterOption = new ColumnFilterValue

--- a/GridBlazor.Tests/TestModel.cs
+++ b/GridBlazor.Tests/TestModel.cs
@@ -19,6 +19,8 @@ namespace GridBlazor.Tests
 
         public Guid GuidField { get; set; }
 
+        public TestEnum EnumField { get; set; }
+
         public override bool Equals(object obj)
         {
             var compareObject = obj as TestModel;
@@ -33,12 +35,13 @@ namespace GridBlazor.Tests
                    && compareObject.UInt16Field == UInt16Field
                    && compareObject.UInt32Field == UInt32Field
                    && compareObject.UInt64Field == UInt64Field
-                   && compareObject.GuidField == GuidField;
+                   && compareObject.GuidField == GuidField
+                   && compareObject.EnumField == EnumField;
         }
 
         public override int GetHashCode()
         {
-            return  new { Id, Title, Child.ChildCreated, Child.ChildTitle, Int16Field, UInt16Field, UInt32Field, UInt64Field, GuidField }.GetHashCode();
+            return new { Id, Title, Child.ChildCreated, Child.ChildTitle, Int16Field, UInt16Field, UInt32Field, UInt64Field, GuidField, EnumField }.GetHashCode();
         }
     } 
 
@@ -46,5 +49,12 @@ namespace GridBlazor.Tests
     {
         public string ChildTitle { get; set; }
         public DateTime ChildCreated { get; set; }
+    }
+
+    public enum TestEnum
+    {
+        Foo,
+        Bar,
+        Baz,
     }
 }

--- a/GridMvc.Tests/Filtering/FilterTests.cs
+++ b/GridMvc.Tests/Filtering/FilterTests.cs
@@ -248,6 +248,30 @@ namespace GridMvc.Tests.Filtering
         }
 
         [TestMethod]
+        public void TestEnumFilteringEquals()
+        {
+            var filterOption = new ColumnFilterValue
+            {
+                ColumnName = "EnumField",
+                FilterType = GridFilterType.Equals,
+                FilterValue = "Foo"
+            };
+            var filterOptions = new List<ColumnFilterValue>();
+            filterOptions.Add(filterOption);
+            var filter = new DefaultColumnFilter<TestModel, TestEnum>(m => m.EnumField);
+
+            var filtered = filter.ApplyFilter(_repo.GetAll().AsQueryable(), filterOptions);
+
+            var original = _repo.GetAll().AsQueryable().Where(t => t.EnumField == TestEnum.Foo);
+
+            for (int i = 0; i < filtered.Count(); i++)
+            {
+                if (filtered.ElementAt(i).Id != original.ElementAt(i).Id)
+                    Assert.Fail("Filtering not works");
+            }
+        }
+
+        [TestMethod]
         public void TestGuidFilterContains()
         {
             var filterOption = new ColumnFilterValue

--- a/GridMvc.Tests/TestModel.cs
+++ b/GridMvc.Tests/TestModel.cs
@@ -19,6 +19,8 @@ namespace GridMvc.Tests
 
         public Guid GuidField { get; set; }
 
+        public TestEnum EnumField { get; set; }
+
         public override bool Equals(object obj)
         {
             var compareObject = obj as TestModel;
@@ -33,12 +35,13 @@ namespace GridMvc.Tests
                    && compareObject.UInt16Field == UInt16Field
                    && compareObject.UInt32Field == UInt32Field
                    && compareObject.UInt64Field == UInt64Field
-                   && compareObject.GuidField == GuidField;
+                   && compareObject.GuidField == GuidField
+                   && compareObject.EnumField == EnumField;
         }
 
         public override int GetHashCode()
         {
-            return new { Id, Title, Child.ChildCreated, Child.ChildTitle, Int16Field, UInt16Field, UInt32Field, UInt64Field, GuidField }.GetHashCode();
+            return new { Id, Title, Child.ChildCreated, Child.ChildTitle, Int16Field, UInt16Field, UInt32Field, UInt64Field, GuidField, EnumField }.GetHashCode();
         }
     } 
 
@@ -46,5 +49,12 @@ namespace GridMvc.Tests
     {
         public string ChildTitle { get; set; }
         public DateTime ChildCreated { get; set; }
+    }
+
+    public enum TestEnum
+    {
+        Foo,
+        Bar,
+        Baz,
     }
 }

--- a/GridShared/Filtering/Types/EnumFilterType.cs
+++ b/GridShared/Filtering/Types/EnumFilterType.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace GridShared.Filtering.Types
+{
+    /// <summary>
+    ///     Object builds filter expressions for Enum grid columns
+    /// </summary>
+    public sealed class EnumFilterType : FilterTypeBase
+    {
+        public EnumFilterType(Type type) => TargetType = type;
+
+        public override Type TargetType { get; }
+
+        public override GridFilterType GetValidType(GridFilterType type)
+            => GridFilterType.Equals;
+
+        public override object GetTypedValue(string value)
+            => Enum.IsDefined(TargetType, value) ? Enum.Parse(TargetType, value, true) : null;
+    }
+}

--- a/GridShared/Filtering/Types/FilterTypeResolver.cs
+++ b/GridShared/Filtering/Types/FilterTypeResolver.cs
@@ -28,6 +28,9 @@ namespace GridShared.Filtering.Types
 
         public IFilterType GetFilterType(Type type)
         {
+            if (type.IsEnum)
+                return new EnumFilterType(type);
+
             foreach (IFilterType filterType in _filterCollection)
             {
                 if (filterType.TargetType.FullName == type.FullName)


### PR DESCRIPTION
Currently, `enum` properties on the model will use the `TextFilterType` for filtering. This doesn't work because it tries to call the `ToUpper` method on an `enum` where it is not defined. I added the `EnumFilterType` to make it work with `enums`.