### PR TITLE
Suggestion: Add BeforeFilterChanged event

### DIFF
--- a/GridShared/Events/FilterEventArgs.cs
+++ b/GridShared/Events/FilterEventArgs.cs
@@ -7,4 +7,9 @@ namespace GridShared.Events
     {
         public IFilterColumnCollection FilteredColumns { get; set; }
     }
+
+    public class FilterEventCancelArgs : EventArgs
+    {
+        public bool Cancel { get; set; } = false;
+    }
 }


### PR DESCRIPTION
Add BeforeFilterChanged event to be able to Cancel filter change before it happens

My actual reason for doing this is that I have a checkbox that I link to a data model field, where the user can do some work. And when a filter is changed, I need to save the state of checkboxes because data is being reloaded when filtering and I loose my user's changes.