### PR TITLE
Add support for more data types (e.g. enums, custom types) in CRUD forms

### DIFF
--- a/GridBlazor/Pages/GridCreateComponent.razor
+++ b/GridBlazor/Pages/GridCreateComponent.razor
@@ -25,298 +25,20 @@
                         @if (((IGridColumn<T>)column).IsSelectField.IsSelectKey)
                         {
                             var selectedValue = column.GetFormatedValue(value);
-                            if (type == typeof(string))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeString(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(DateTime))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeDateTime(e, column, null)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.DateTimeOffset))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeDateTimeOffset(e, column, null)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.TimeSpan))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeTimeSpan(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.Int32))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeInt32(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.Double))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeDouble(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.Decimal))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeDecimal(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.Byte))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeByte(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.Single))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeSingle(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.Int64))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeInt64(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.Int16))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeInt16(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.UInt64))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeUInt64(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.UInt32))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeUInt32(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(System.UInt16))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeUInt16(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                    {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
-                                    }
-                                </select>
-                            }
-                            else if (type == typeof(bool))
-                            {
-                                if (value != null && (bool)value == true)
+                            <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeValue(e, column)">
+                                <option value="">@Strings.SelectItem</option>
+                                @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
                                 {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeBool(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeBool(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                            }
-                            else if (type == typeof(System.Guid))
-                            {
-                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeGuid(e, column)">
-                                    <option value="">@Strings.SelectItem</option>
-                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
+                                    if (selectItem.Value == selectedValue)
                                     {
-                                        if (selectItem.Value == selectedValue)
-                                        {
-                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                        }
-                                        else
-                                        {
-                                            <option value="@selectItem.Value">@selectItem.Title</option>
-                                        }
+                                        <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
                                     }
-                                </select>
-                            }
+                                    else
+                                    {
+                                        <option value="@selectItem.Value">@selectItem.Title</option>
+                                    }
+                                }
+                            </select>
                         }
                         else
                         {
@@ -324,16 +46,9 @@
                             {
                                 <input id="@column.FieldName" name="@column.FieldName" class="form-control" readonly="readonly" value="@column.GetFormatedValue(value)" />
                             }
-                            else if (type == typeof(string))
+                            else if (type == typeof(string) && ((IGridColumn<T>)column).InputType == InputType.TextArea)
                             {
-                                if (((IGridColumn<T>)column).InputType == InputType.TextArea)
-                                {
-                                    <textarea id="@column.FieldName" name="@column.FieldName" class="form-control" rows="5" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeString(e, column)" />
-                                }
-                                else
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeString(e, column)" />
-                                }
+                                <textarea id="@column.FieldName" name="@column.FieldName" class="form-control" rows="5" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeValue(e, column)" />
                             }
                             else if (type == typeof(DateTime))
                             {
@@ -342,38 +57,38 @@
                                 {
                                     if (GridComponent._isWeekSupported)
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-Www" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-Www" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                     else
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-Www" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-Www" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                 }
                                 else if (typeAttr == "month")
                                 {
                                     if (GridComponent._isMonthSupported)
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                     else
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                 }
                                 else if (typeAttr == "datetime-local")
                                 {
                                     if (GridComponent._isDateTimeLocalSupported)
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-mm-dd hh:mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-mm-dd hh:mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                     else
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-mm-dd hh:mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-mm-dd hh:mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                 }
                                 else
                                 {
-                                    <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                    <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                 }
                             }
                             else if (type == typeof(System.DateTimeOffset))
@@ -383,103 +98,59 @@
                                 {
                                     if (GridComponent._isWeekSupported)
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                     else
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                 }
                                 else if (typeAttr == "month")
                                 {
                                     if (GridComponent._isMonthSupported)
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                     else
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                 }
                                 else if (typeAttr == "datetime-local")
                                 {
                                     if (GridComponent._isDateTimeLocalSupported)
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                     else
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                 }
                                 else
                                 {
-                                    <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                    <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                 }
                             }
                             else if (type == typeof(System.TimeSpan))
                             {
                                 string typeAttr = ((IGridColumn<T>)column).InputType == InputType.None ? "time" : ((IGridColumn<T>)column).InputType.ToTypeAttr();
-                                <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeTimeSpan(e, column)" />
-                            }
-                            else if (type == typeof(System.Int32))
-                            {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeInt32(e, column)" />
-                            }
-                            else if (type == typeof(System.Double))
-                            {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeDouble(e, column)" />
-                            }
-                            else if (type == typeof(System.Decimal))
-                            {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeDecimal(e, column)" />
-                            }
-                            else if (type == typeof(System.Byte))
-                            {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeByte(e, column)" />
-                            }
-                            else if (type == typeof(System.Single))
-                            {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeSingle(e, column)" />
-                            }
-                            else if (type == typeof(System.Int64))
-                            {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeInt64(e, column)" />
-                            }
-                            else if (type == typeof(System.Int16))
-                            {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeInt16(e, column)" />
-                            }
-                            else if (type == typeof(System.UInt64))
-                            {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeUInt64(e, column)" />
-                            }
-                            else if (type == typeof(System.UInt32))
-                            {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeUInt32(e, column)" />
-                            }
-                            else if (type == typeof(System.UInt16))
-                            {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeUInt16(e, column)" />
+                                <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column)" />
                             }
                             else if (type == typeof(bool))
                             {
                                 if (value != null && (bool)value == true)
                                 {
-                                    <input id="@column.FieldName" name="@column.FieldName" type="checkbox" class="form-control" checked="checked" value="true" @onchange="(e) => ChangeBool(e, column)" />
+                                    <input id="@column.FieldName" name="@column.FieldName" type="checkbox" class="form-control" checked="checked" value="true" @onchange="(e) => ChangeValue(e, column)" />
                                 }
                                 else
                                 {
-                                    <input id="@column.FieldName" name="@column.FieldName" type="checkbox" class="form-control" value="false" @onchange="(e) => ChangeBool(e, column)" />
+                                    <input id="@column.FieldName" name="@column.FieldName" type="checkbox" class="form-control" value="false" @onchange="(e) => ChangeValue(e, column)" />
                                 }
-                            }
-                            else if (type == typeof(System.Guid))
-                            {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeGuid(e, column)" />
                             }
                             else
                             {
-                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" readonly="readonly" value="@column.GetFormatedValue(value)" />
+                                <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeValue(e, column)" />
                             }
                         }
                     </div>

--- a/GridBlazor/Pages/GridCreateComponent.razor.cs
+++ b/GridBlazor/Pages/GridCreateComponent.razor.cs
@@ -4,6 +4,7 @@ using GridShared.Utility;
 using Microsoft.AspNetCore.Components;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -71,12 +72,7 @@ namespace GridBlazor.Pages
             pi.SetValue(obj, value, null);
         }
 
-        protected void ChangeString(ChangeEventArgs e, IGridColumn column)
-        {
-            ChangeValue(e.Value.ToString(), column);
-        }
-
-        protected void ChangeDateTime(ChangeEventArgs e, IGridColumn column, string typeAttr)
+        private void ChangeValue(ChangeEventArgs e, IGridColumn column, string typeAttr = null)
         {
             if (string.IsNullOrWhiteSpace(e.Value.ToString()))
             {
@@ -96,308 +92,18 @@ namespace GridBlazor.Pages
                 }
                 else
                 {
-                    DateTime value;
-                    if (DateTime.TryParse(e.Value.ToString(), out value))
+                    var (type, _) = ((IGridColumn<T>)column).GetTypeAndValue(Item);
+                    var typeConverter = TypeDescriptor.GetConverter(type);
+
+                    if (typeConverter.IsValid(e.Value))
                     {
+                        var value = typeConverter.ConvertFrom(e.Value);
                         ChangeValue(value, column);
                     }
                     else
                     {
                         ChangeValue(null, column);
                     }
-                }
-            }
-        }
-
-        protected void ChangeDateTimeOffset(ChangeEventArgs e, IGridColumn column, string typeAttr)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                if (typeAttr == "week")
-                {
-                    var value = DateTimeUtils.FromIso8601WeekDate(e.Value.ToString());
-                    ChangeValue(value, column);
-                }
-                else if (typeAttr == "month")
-                {
-                    var value = DateTimeUtils.FromMonthDate(e.Value.ToString());
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    DateTimeOffset value;
-                    if (DateTimeOffset.TryParse(e.Value.ToString(), out value))
-                    {
-                        ChangeValue(value, column);
-                    }
-                    else
-                    {
-                        ChangeValue(null, column);
-                    }
-                }
-            }
-        }
-
-        protected void ChangeTimeSpan(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                TimeSpan value;
-                if (TimeSpan.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeInt32(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Int32 value;
-                if (Int32.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeDouble(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Double value;
-                if (Double.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeDecimal(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Decimal value;
-                if (Decimal.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeByte(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Byte value;
-                if (Byte.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeSingle(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Single value;
-                if (Single.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeInt64(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Int64 value;
-                if (Int64.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeInt16(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Int16 value;
-                if (Int16.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeUInt64(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                UInt64 value;
-                if (UInt64.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeUInt32(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                UInt32 value;
-                if (UInt32.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeUInt16(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                UInt16 value;
-                if (UInt16.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeBool(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                bool value;
-                if (bool.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeGuid(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Guid value;
-                if (Guid.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
                 }
             }
         }

--- a/GridBlazor/Pages/GridUpdateComponent.razor
+++ b/GridBlazor/Pages/GridUpdateComponent.razor
@@ -36,298 +36,20 @@
                             else
                             {
                                 var selectedValue = column.GetFormatedValue(value);
-                                if (type == typeof(string))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeString(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(DateTime))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeDateTime(e, column, null)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.DateTimeOffset))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeDateTimeOffset(e, column, null)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.TimeSpan))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeTimeSpan(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.Int32))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeInt32(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.Double))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeDouble(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.Decimal))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeDecimal(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.Byte))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeByte(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.Single))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeSingle(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.Int64))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeInt64(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.Int16))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeInt16(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.UInt64))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeUInt64(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.UInt32))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeUInt32(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(System.UInt16))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeUInt16(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                        {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
-                                        }
-                                    </select>
-                                }
-                                else if (type == typeof(bool))
-                                {
-                                    if (value != null && (bool)value == true)
+                                <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeValue(e, column)">
+                                    <option value="">@Strings.SelectItem</option>
+                                    @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
                                     {
-                                        <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeBool(e, column)">
-                                            <option value="">@Strings.SelectItem</option>
-                                            @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                            {
-                                                if (selectItem.Value == selectedValue)
-                                                {
-                                                    <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                                }
-                                                else
-                                                {
-                                                    <option value="@selectItem.Value">@selectItem.Title</option>
-                                                }
-                                            }
-                                        </select>
-                                    }
-                                    else
-                                    {
-                                        <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeBool(e, column)">
-                                            <option value="">@Strings.SelectItem</option>
-                                            @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
-                                            {
-                                                if (selectItem.Value == selectedValue)
-                                                {
-                                                    <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                                }
-                                                else
-                                                {
-                                                    <option value="@selectItem.Value">@selectItem.Title</option>
-                                                }
-                                            }
-                                        </select>
-                                    }
-                                }
-                                else if (type == typeof(System.Guid))
-                                {
-                                    <select id="@column.FieldName" name="@column.FieldName" class="form-control" value="@selectedValue" @onchange="(e) => ChangeGuid(e, column)">
-                                        <option value="">@Strings.SelectItem</option>
-                                        @foreach (var selectItem in ((IGridColumn<T>)column).SelectItems)
+                                        if (selectItem.Value == selectedValue)
                                         {
-                                            if (selectItem.Value == selectedValue)
-                                            {
-                                                <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
-                                            }
-                                            else
-                                            {
-                                                <option value="@selectItem.Value">@selectItem.Title</option>
-                                            }
+                                            <option value="@selectItem.Value" selected="selected">@selectItem.Title</option>
                                         }
-                                    </select>
-                                }
+                                        else
+                                        {
+                                            <option value="@selectItem.Value">@selectItem.Title</option>
+                                        }
+                                    }
+                                </select>
                             }
                         }
                         else
@@ -352,16 +74,9 @@
                             }
                             else
                             {
-                                if (type == typeof(string))
+                                if (type == typeof(string) && ((IGridColumn<T>)column).InputType == InputType.TextArea)
                                 {
-                                    if (((IGridColumn<T>)column).InputType == InputType.TextArea)
-                                    {
-                                        <textarea id="@column.FieldName" name="@column.FieldName" class="form-control" rows="5" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeString(e, column)" />
-                                    }
-                                    else
-                                    {
-                                        <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeString(e, column)" />
-                                    }
+                                    <textarea id="@column.FieldName" name="@column.FieldName" class="form-control" rows="5" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeValue(e, column)" />
                                 }
                                 else if (type == typeof(DateTime))
                                 {
@@ -370,38 +85,38 @@
                                     {
                                         if (GridComponent._isWeekSupported)
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-Www" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-Www" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                         else
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-Www" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-Www" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                     }
                                     else if (typeAttr == "month")
                                     {
                                         if (GridComponent._isMonthSupported)
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                         else
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                     }
                                     else if (typeAttr == "datetime-local")
                                     {
                                         if (GridComponent._isDateTimeLocalSupported)
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-mm-dd hh:mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" placeholder="yyyy-mm-dd hh:mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                         else
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-mm-dd hh:mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="text" placeholder="yyyy-mm-dd hh:mm" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                     }
                                     else
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTime(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                 }
                                 else if (type == typeof(System.DateTimeOffset))
@@ -411,103 +126,59 @@
                                     {
                                         if (GridComponent._isWeekSupported)
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                         else
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                     }
                                     else if (typeAttr == "month")
                                     {
                                         if (GridComponent._isMonthSupported)
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                         else
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                     }
                                     else if (typeAttr == "datetime-local")
                                     {
                                         if (GridComponent._isDateTimeLocalSupported)
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                         else
                                         {
-                                            <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                            <input id="@column.FieldName" name="@column.FieldName" type="text" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                         }
                                     }
                                     else
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeDateTimeOffset(e, column, typeAttr)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column, typeAttr)" />
                                     }
                                 }
                                 else if (type == typeof(System.TimeSpan))
                                 {
                                     string typeAttr = ((IGridColumn<T>)column).InputType == InputType.None ? "time" : ((IGridColumn<T>)column).InputType.ToTypeAttr();
-                                    <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeTimeSpan(e, column)" />
-                                }
-                                else if (type == typeof(System.Int32))
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeInt32(e, column)" />
-                                }
-                                else if (type == typeof(System.Double))
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeDouble(e, column)" />
-                                }
-                                else if (type == typeof(System.Decimal))
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeDecimal(e, column)" />
-                                }
-                                else if (type == typeof(System.Byte))
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeByte(e, column)" />
-                                }
-                                else if (type == typeof(System.Single))
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeSingle(e, column)" />
-                                }
-                                else if (type == typeof(System.Int64))
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeInt64(e, column)" />
-                                }
-                                else if (type == typeof(System.Int16))
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeInt16(e, column)" />
-                                }
-                                else if (type == typeof(System.UInt64))
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeUInt64(e, column)" />
-                                }
-                                else if (type == typeof(System.UInt32))
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeUInt32(e, column)" />
-                                }
-                                else if (type == typeof(System.UInt16))
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeUInt16(e, column)" />
+                                    <input id="@column.FieldName" name="@column.FieldName" type="@typeAttr" class="form-control" value="@(((GridColumnBase<T>)column).GetFormatedDateTime(value, typeAttr))" @onchange="(e) => ChangeValue(e, column)" />
                                 }
                                 else if (type == typeof(bool))
                                 {
                                     if (value != null && (bool)value == true)
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="checkbox" class="form-control" checked="checked" value="true" @onchange="(e) => ChangeBool(e, column)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="checkbox" class="form-control" checked="checked" value="true" @onchange="(e) => ChangeValue(e, column)" />
                                     }
                                     else
                                     {
-                                        <input id="@column.FieldName" name="@column.FieldName" type="checkbox" class="form-control" value="false" @onchange="(e) => ChangeBool(e, column)" />
+                                        <input id="@column.FieldName" name="@column.FieldName" type="checkbox" class="form-control" value="false" @onchange="(e) => ChangeValue(e, column)" />
                                     }
-                                }
-                                else if (type == typeof(System.Guid))
-                                {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" @onchange="(e) => ChangeGuid(e, column)" />
                                 }
                                 else
                                 {
-                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" readonly="readonly" value="@column.GetFormatedValue(value)" />
+                                    <input id="@column.FieldName" name="@column.FieldName" class="form-control" value="@column.GetFormatedValue(value)" />
                                 }
                             }
                         }

--- a/GridBlazor/Pages/GridUpdateComponent.razor.cs
+++ b/GridBlazor/Pages/GridUpdateComponent.razor.cs
@@ -5,6 +5,7 @@ using GridShared.Utility;
 using Microsoft.AspNetCore.Components;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -87,12 +88,7 @@ namespace GridBlazor.Pages
             pi.SetValue(obj, value, null);
         }
 
-        protected void ChangeString(ChangeEventArgs e, IGridColumn column)
-        {
-            ChangeValue(e.Value.ToString(), column);
-        }
-
-        protected void ChangeDateTime(ChangeEventArgs e, IGridColumn column, string typeAttr)
+        private void ChangeValue(ChangeEventArgs e, IGridColumn column, string typeAttr = null)
         {
             if (string.IsNullOrWhiteSpace(e.Value.ToString()))
             {
@@ -112,308 +108,18 @@ namespace GridBlazor.Pages
                 }
                 else
                 {
-                    DateTime value;
-                    if (DateTime.TryParse(e.Value.ToString(), out value))
+                    var (type, _) = ((IGridColumn<T>)column).GetTypeAndValue(Item);
+                    var typeConverter = TypeDescriptor.GetConverter(type);
+
+                    if (typeConverter.IsValid(e.Value))
                     {
+                        var value = typeConverter.ConvertFrom(e.Value);
                         ChangeValue(value, column);
                     }
                     else
                     {
                         ChangeValue(null, column);
                     }
-                }
-            }
-        }
-
-        protected void ChangeDateTimeOffset(ChangeEventArgs e, IGridColumn column, string typeAttr)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                if (typeAttr == "week")
-                {
-                    var value = DateTimeUtils.FromIso8601WeekDate(e.Value.ToString());
-                    ChangeValue(value, column);
-                }
-                else if (typeAttr == "month")
-                {
-                    var value = DateTimeUtils.FromMonthDate(e.Value.ToString());
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    DateTimeOffset value;
-                    if (DateTimeOffset.TryParse(e.Value.ToString(), out value))
-                    {
-                        ChangeValue(value, column);
-                    }
-                    else
-                    {
-                        ChangeValue(null, column);
-                    }
-                }
-            }
-        }
-
-        protected void ChangeTimeSpan(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                TimeSpan value;
-                if (TimeSpan.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeInt32(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Int32 value;
-                if (Int32.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeDouble(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Double value;
-                if (Double.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeDecimal(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Decimal value;
-                if (Decimal.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeByte(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Byte value;
-                if (Byte.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeSingle(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Single value;
-                if (Single.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeInt64(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Int64 value;
-                if (Int64.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeInt16(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Int16 value;
-                if (Int16.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeUInt64(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                UInt64 value;
-                if (UInt64.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeUInt32(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                UInt32 value;
-                if (UInt32.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeUInt16(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                UInt16 value;
-                if (UInt16.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeBool(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                bool value;
-                if (bool.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
-                }
-            }
-        }
-
-        protected void ChangeGuid(ChangeEventArgs e, IGridColumn column)
-        {
-            if (string.IsNullOrWhiteSpace(e.Value.ToString()))
-            {
-                ChangeValue(null, column);
-            }
-            else
-            {
-                Guid value;
-                if (Guid.TryParse(e.Value.ToString(), out value))
-                {
-                    ChangeValue(value, column);
-                }
-                else
-                {
-                    ChangeValue(null, column);
                 }
             }
         }

--- a/docs/blazor_server/Crud.md
+++ b/docs/blazor_server/Crud.md
@@ -115,6 +115,8 @@ The type of fields currently supported as foreign keys are:
 - Decimal
 - bool
 - Guid
+- enums
+- custom types using a [type converter](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.typeconverter)
 
 This is an example of function to get values and title for a drop-down:
 


### PR DESCRIPTION
Add support for more data types (e.g. enums, custom types) in CRUD create & update forms by using [type converters](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.typeconverter).

Benefits of using type converters:
- This makes it possible to replace all the methods to change a specific type (e.g. ChangeString, ChangeDateTime, ChangeDouble, ChangeBool, etc.) with a single generic method, thus removing a lot of the code duplication in the CRUD components.
- Enables support for more data types. For example, enums will automatically be supported. Also, for custom types, the user can define a custom type converter to enable create & update support in the CRUD forms.