### PR TITLE
Checkbox component load initial value even when header checkbox is null

### DIFF
--- a/GridBlazor/Pages/CheckboxComponent.razor.cs
+++ b/GridBlazor/Pages/CheckboxComponent.razor.cs
@@ -54,20 +54,17 @@ namespace GridBlazor.Pages
 
             // init value when header checkbox is enabled and is not null
             var header = GridComponent.HeaderComponents.Get(_columnName);
+            var exceptCheckedRows = GridComponent.ExceptCheckedRows.Get(_columnName);
+            var keys = GridComponent.Grid.GetPrimaryKeyValues(Item);
+            string stringKeys = string.Join('_', keys);
+
             if (header != null && header.IsChecked().HasValue)
+                _value = header.IsChecked().Value;
+
+            if (exceptCheckedRows != null && !string.IsNullOrWhiteSpace(stringKeys))
             {
-                var exceptCheckedRows = GridComponent.ExceptCheckedRows.Get(_columnName);
-                var keys = GridComponent.Grid.GetPrimaryKeyValues(Item);
-                string stringKeys = string.Join('_', keys);
-                if (exceptCheckedRows != null && !string.IsNullOrWhiteSpace(stringKeys))
-                {
-                    if(exceptCheckedRows.ContainsKey(stringKeys))
-                        _value = exceptCheckedRows.Get(stringKeys);
-                    else
-                        _value = header.IsChecked().Value;
-                }
-                else
-                    _value = header.IsChecked().Value;
+                if(exceptCheckedRows.ContainsKey(stringKeys))
+                    _value = exceptCheckedRows.Get(stringKeys);
             }
         }
 


### PR DESCRIPTION
**Bug**
1. Open https://gridblazor.azurewebsites.net/checkbox
2. Change any checkboxes manually (don't click header checkbox)
3. Go to page 2, and then come back to page 1
4. Any changes that were made are reset

**Working**
1. Open https://gridblazor.azurewebsites.net/checkbox
2. Click header checkbox to select all rows, click again to unselect all
3. Change some checkboxes manually
4. Go to page 2, and then come back to page 1
5. Now the changes you made are kept

**This PR fixes the issue, so that changes in first scenario are kept**