### PR TITLE
Fix some Swedish localization errors

### DIFF
--- a/GridMvc.Demo/Views/Shared/_Layout.cshtml
+++ b/GridMvc.Demo/Views/Shared/_Layout.cshtml
@@ -142,7 +142,7 @@
         @RenderBody()
         <hr />
         <footer>
-            <p>&copy; 2017 - GridMvc.Demo</p>
+            <p>&copy; 2020 - GridMvc.Demo</p>
         </footer>
     </div>
 

--- a/GridMvc.Demo/Views/Shared/_Layout.cshtml
+++ b/GridMvc.Demo/Views/Shared/_Layout.cshtml
@@ -30,6 +30,7 @@
         <script src="~/js/gridmvc-lang-nl.js"></script>
         <script src="~/js/gridmvc-lang-tr.js"></script>
         <script src="~/js/gridmvc-lang-cs.js"></script>
+        <script src="~/js/gridmvc-lang-se.js"></script>
         <script src="~/js/gridmvc-lang-sl.js"></script>
         <script src="~/js/gridmvc-lang-sr.js"></script>
         <script src="~/js/gridmvc-lang-hr.js"></script>
@@ -72,6 +73,7 @@
         <script src="~/js/gridmvc-lang-nb.js"></script>
         <script src="~/js/gridmvc-lang-tr.js"></script>
         <script src="~/js/gridmvc-lang-cs.js"></script>
+        <script src="~/js/gridmvc-lang-se.js"></script>
         <script src="~/js/gridmvc-lang-sl.js"></script>
         <script src="~/js/gridmvc-lang-sr.js"></script>
         <script src="~/js/gridmvc-lang-hr.js"></script>

--- a/GridMvc/Resources/js/gridmvc-lang-de.js
+++ b/GridMvc/Resources/js/gridmvc-lang-de.js
@@ -1,5 +1,5 @@
 ﻿/***
-* Grid.Mvc gernam language (de-DE)
+* Grid.Mvc german language (de-DE)
 */
 window.GridMvc = window.GridMvc || {};
 window.GridMvc.lang = window.GridMvc.lang || {};

--- a/docs/blazor_client/Localization.md
+++ b/docs/blazor_client/Localization.md
@@ -25,7 +25,7 @@ English is the default laguage. But you can use other languages. You have to cre
 * Turkish
 * Czech
 * Slovenian
-* Sweden
+* Swedish
 * Serbian
 * Croatian
 * Farsi

--- a/docs/blazor_odata/Localization.md
+++ b/docs/blazor_odata/Localization.md
@@ -25,7 +25,7 @@ English is the default laguage. But you can use other languages. You have to cre
 * Turkish
 * Czech
 * Slovenian
-* Sweden
+* Swedish
 * Serbian
 * Croatian
 * Farsi

--- a/docs/blazor_server/Localization.md
+++ b/docs/blazor_server/Localization.md
@@ -23,7 +23,7 @@ English is the default laguage. But you can use other languages. You have to cre
 * Turkish
 * Czech
 * Slovenian
-* Sweden
+* Swedish
 * Serbian
 * Croatian
 * Farsi

--- a/docs/dotnetcore_blazor/Localization.md
+++ b/docs/dotnetcore_blazor/Localization.md
@@ -23,7 +23,7 @@ English is the default laguage. But you can use other languages. You have to cre
 * Turkish
 * Czech
 * Slovenian
-* Sweden
+* Swedish
 * Serbian
 * Croatian
 * Farsi


### PR DESCRIPTION
It seemed to be some file import errors, since the swedish locale did not show in the language selector. 

- Fixed some errors so the Swedish language are now correctly displayed. 
- Also added 2020 to the demo page instead of 2017, since it now use the .NET5.0