### PR TITLE
Odata string key

### DIFF
--- a/GridBlazor/OData/ODataService.cs
+++ b/GridBlazor/OData/ODataService.cs
@@ -69,7 +69,6 @@ namespace GridBlazor.OData
                 throw new GridException("ODATA-03", "Error deleting the order");
             }
         }
-
         public static string GetUrl(CGrid<T> grid, string url, params object[] keys)
         {
             var keyNames = grid.GetPrimaryKeys();
@@ -80,17 +79,17 @@ namespace GridBlazor.OData
             else
                 expandParameters = "?" + expandParameters;
 
-            if (keyNames.Length != keys.Length || keys.Length == 1)
-                return url + "(" + string.Join(",", keys.Select(x => x.ToString())) + ")" + expandParameters;
-            else
+            bool includeKeyname = !(keyNames.Length != keys.Length || keys.Length == 1);
+
+            var keysUrl = new List<string>(); ;
+            for (int i = 0; i < keys.Length; i++)
             {
-                var keysUrl = new List<string>(); ;
-                for (int i = 0; i < keys.Length; i++)
-                {
-                    keysUrl.Add(keyNames[i] + "=" + keys[i].ToString());
-                }
-                return url + "(" + string.Join(",", keysUrl.Select(x => x.ToString())) + ")" + expandParameters;
+                string keyDelimiter = int.TryParse(keys[i].ToString(), out int n) ? string.Empty : "'";
+                string keyName = includeKeyname ? $"{keyNames[i]}=" : string.Empty;
+                keysUrl.Add($"{keyName}{keyDelimiter}{keys[i]}{keyDelimiter}");
             }
+            return url + "(" + string.Join(",", keysUrl.Select(x => x.ToString())) + ")" + expandParameters;
+
         }
     }
 }

--- a/GridBlazor/OData/ODataService.cs
+++ b/GridBlazor/OData/ODataService.cs
@@ -35,7 +35,7 @@ namespace GridBlazor.OData
             var response = await _httpClient.PostAsJsonAsync<T>(_url, item, _jsonOptions);
             if (response.IsSuccessStatusCode)
             {
-                return await response.Content.ReadFromJsonAsync<T>();     
+                return await response.Content.ReadFromJsonAsync<T>(_jsonOptions);     
             }
             else
             {


### PR DESCRIPTION
Hi,

I would like to merge this commit.
I'm not that confident if this is 100% correct.
But please be so kind to provide advice if I'm wrong.

I have an odata endpoint. 
Microsoft.AspNetCore.OData Version="7.5.6"
Where the key is not an int but a string.

the key fails do bind / find the route when i just call.
Odata\Client(the client name)
I need to call it with ' around the keyname
Odata\Client('the client name')

This was not supported in the GetUrl method.

I made a path for this.
Not sure if this is the best / cleanest solution.

Hope you want to merge this :) 

br
