### PR TITLE
Resolves #242 partly, ability to reorder columns by drag and drop

### DIFF
--- a/GridBlazor/CGrid.cs
+++ b/GridBlazor/CGrid.cs
@@ -168,6 +168,8 @@ namespace GridBlazor
         public bool GroupingEnabled { get; set; }
 
         public bool ClearFiltersButtonEnabled { get; set; } = false;
+        
+        public bool RearrangeColumnEnabled { get; set; }
 
         /// <summary>
         ///     Items, displaying in the grid view
@@ -591,6 +593,20 @@ namespace GridBlazor
                 }
             }
             return values.ToArray();
+        }
+
+        public Task InsertColumn(IGridColumn targetColumn, IGridColumn insertingColumn)
+        {
+            var removed = _columnsCollection.Remove(insertingColumn);
+            if (!removed)
+                return Task.CompletedTask;
+            
+            var index = _columnsCollection.IndexOf(targetColumn);
+            if (index == -1)
+                return Task.CompletedTask;
+
+            _columnsCollection.Insert(index, insertingColumn);
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/GridBlazor/Client/GridClient.cs
+++ b/GridBlazor/Client/GridClient.cs
@@ -187,6 +187,17 @@ namespace GridBlazor
             return this;
         }
 
+        public IGridClient<T> RearrangeableColumns()
+        {
+            return RearrangeableColumns(true);
+        }
+
+        public IGridClient<T> RearrangeableColumns(bool enable)
+        {
+            _source.RearrangeColumnEnabled = enable;
+            return this;
+        }
+
         public IGridClient<T> ClearFiltersButton(bool enable)
         {
             _source.ClearFiltersButtonEnabled = enable;

--- a/GridBlazor/Client/IGridClient.cs
+++ b/GridBlazor/Client/IGridClient.cs
@@ -100,6 +100,16 @@ namespace GridBlazor
         ///     Enable or disable grouping
         /// </summary>
         IGridClient<T> Groupable(bool enable);
+        
+        /// <summary>
+        ///     Enable column rearrange
+        /// </summary>
+        IGridClient<T> RearrangeableColumns();
+
+        /// <summary>
+        ///     Enable or disable column rearrange
+        /// </summary>
+        IGridClient<T> RearrangeableColumns(bool enable);
 
         /// <summary>
         ///     Enable or disable visibility of ClearFiltersButton

--- a/GridBlazor/ICGrid.cs
+++ b/GridBlazor/ICGrid.cs
@@ -43,6 +43,11 @@ namespace GridBlazor
         /// </summary>
         bool SubGridsOpened { get; }
 
+        /// <summary>
+        ///     Set or get default value of rearrange column
+        /// </summary>
+        public bool RearrangeColumnEnabled { get; set; }
+
         Type Type { get; }
 
         string Url { get; }
@@ -90,6 +95,8 @@ namespace GridBlazor
         void RemoveAllFilters();
 
         Task DownloadExcel(IJSRuntime js, string filename);
+
+        Task InsertColumn(IGridColumn targetColumn, IGridColumn insertingColumn);
 
         /// <summary>
         ///     Get and set export to an Excel file

--- a/GridBlazor/Pages/GridComponent.razor.cs
+++ b/GridBlazor/Pages/GridComponent.razor.cs
@@ -920,6 +920,25 @@ namespace GridBlazor.Pages
                 await AfterDeleteForm.Invoke(this, _item);
             }
         }
+        
+        public async Task HandleColumnRearranged(GridHeaderComponent<T> gridHeaderComponent)
+        {
+            if (Payload == ColumnOrderValue.Null)
+                return;
+
+            var payload = Payload;
+            Payload = ColumnOrderValue.Null;
+            if (gridHeaderComponent.Column.Name == payload.ColumnName)
+                return;
+
+            var source = Grid.Columns.FirstOrDefault(c => c.Name == payload.ColumnName);
+            if (source is null)
+                return;
+
+            await Grid.InsertColumn(gridHeaderComponent.Column, source);
+            _shouldRender = true;
+            StateHasChanged();
+        }
 
         public async Task ExcelHandler()
         {

--- a/GridBlazor/Pages/GridHeaderComponent.razor
+++ b/GridBlazor/Pages/GridHeaderComponent.razor
@@ -4,7 +4,21 @@
 @typeparam T
 
 <th class="@_cssClass" style="@_cssStyles">
-    <div class="grid-header-group">
+    <div class="grid-header-group"
+        @ondragenter="@(() => HandleDragEnter())" 
+        @ondragleave="@(() => HandleDragLeave())" 
+        @ondrop="HandleDrop" 
+        ondragover="event.preventDefault();"
+    >
+        @if (GridComponent.Grid.RearrangeColumnEnabled
+                && !string.IsNullOrEmpty(_dropClass))
+        {
+            <div class="grid-column-rearrange-insert-placeholder">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-geo-fill" viewBox="0 0 16 16">
+                  <path fill-rule="evenodd" d="M4 4a4 4 0 1 1 4.5 3.969V13.5a.5.5 0 0 1-1 0V7.97A4 4 0 0 1 4 3.999zm2.493 8.574a.5.5 0 0 1-.411.575c-.712.118-1.28.295-1.655.493a1.319 1.319 0 0 0-.37.265.301.301 0 0 0-.057.09V14l.002.008a.147.147 0 0 0 .016.033.617.617 0 0 0 .145.15c.165.13.435.27.813.395.751.25 1.82.414 3.024.414s2.273-.163 3.024-.414c.378-.126.648-.265.813-.395a.619.619 0 0 0 .146-.15.148.148 0 0 0 .015-.033L12 14v-.004a.301.301 0 0 0-.057-.09 1.318 1.318 0 0 0-.37-.264c-.376-.198-.943-.375-1.655-.493a.5.5 0 1 1 .164-.986c.77.127 1.452.328 1.957.594C12.5 13 13 13.4 13 14c0 .426-.26.752-.544.977-.29.228-.68.413-1.116.558-.878.293-2.059.465-3.34.465-1.281 0-2.462-.172-3.34-.465-.436-.145-.826-.33-1.116-.558C3.26 14.752 3 14.426 3 14c0-.599.5-1 .961-1.243.505-.266 1.187-.467 1.957-.594a.5.5 0 0 1 .575.411z"/>
+                </svg>
+            </div>   
+        }
         @if (Column.HeaderCheckbox)
         {
             <div class="grid-header-checkbox">
@@ -19,7 +33,7 @@
                 }
             </div>
         }
-        @if (Column.ParentGrid.ExtSortingEnabled)
+        @if (Column.ParentGrid.ExtSortingEnabled || GridComponent.Grid.RearrangeColumnEnabled)
         {
             <div class="grid-extsort-draggable @_cssSortingClass" draggable="true" data-column="@Column.Name" @ondragstart="() => HandleDragStart()" @onmouseover="DisplayTooltip" @onmouseout="HideTooltip">
                 @if (Column.SortEnabled)

--- a/GridBlazor/Pages/GridHeaderComponent.razor.cs
+++ b/GridBlazor/Pages/GridHeaderComponent.razor.cs
@@ -36,6 +36,8 @@ namespace GridBlazor.Pages
         private bool? _allChecked = null;
         private bool _showAllChecked = false;
 
+        protected string _dropClass = "";
+
         protected string _cssStyles;
         protected string _cssClass;
         protected string _cssFilterClass;
@@ -274,6 +276,35 @@ namespace GridBlazor.Pages
             var maxId = values.Any() ? values.Max(x => x.Id) + 1 : 1;
             GridComponent.Payload = new ColumnOrderValue(Column.Name, Column.Direction ?? GridSortDirection.Ascending, maxId);
             _shouldRender = true;
+        }
+
+        protected void HandleDragEnter()
+        {
+            if (!GridComponent.Grid.RearrangeColumnEnabled)
+                return;
+
+            _dropClass = "grid-header-drag-over";
+            _shouldRender = true;
+        }
+
+        protected void HandleDragLeave()
+        {
+            if (!GridComponent.Grid.RearrangeColumnEnabled)
+                return;
+
+            _dropClass = "";
+            _shouldRender = true;
+        }
+
+        protected async Task HandleDrop()
+        {
+            if (!GridComponent.Grid.RearrangeColumnEnabled)
+                return;
+
+            _dropClass = "";
+            _shouldRender = true;
+
+            await GridComponent.HandleColumnRearranged(this);
         }
 
         private void HideFilter()

--- a/GridBlazor/wwwroot/css/gridblazor.css
+++ b/GridBlazor/wwwroot/css/gridblazor.css
@@ -201,10 +201,30 @@ div[dir="rtl"] button.grid-button-component { margin-left: 5px; margin-right: 0;
 .grid-header-checkbox-input { opacity: 0; }
     .grid-header-checkbox-input ~ .null-checkbox::before { position: absolute; top: 1rem; display: block; width: .9rem; height: .9rem; pointer-events: none; content: ""; border: 0.5px solid #666; border-radius: 3px; background-color: #ccc; }
 
-div[dir="rtl"] label { display: flex; }
+div[dir="rtl"] label {
+    display: flex;
+}
+
+/* Grid drag over header */
+.grid-header-drag-over {
+    border: 1px solid lightblue;
+    border-radius: 5px;
+}
+
+.grid-column-rearrange-insert-placeholder{
+    margin-left: -0.25rem;
+}
 
 /* The switch - the box around the slider */
-.grid-switch { position: relative; display: inline-block; width: 50px; height: 24px; margin-left: 16px; margin-right: 16px; margin-bottom: -8px; }
+.grid-switch {
+    position: relative;
+    display: inline-block;
+    width: 50px;
+    height: 24px;
+    margin-left: 16px;
+    margin-right: 16px;
+    margin-bottom: -8px;
+}
 
     /* Hide default HTML checkbox */
     .grid-switch input { display: none; }

--- a/GridBlazorClientSide.Client/Pages/RearrangeableColumns.razor
+++ b/GridBlazorClientSide.Client/Pages/RearrangeableColumns.razor
@@ -1,0 +1,58 @@
+﻿@page "/rearrangeable"
+@using GridBlazorClientSide.Client.ColumnCollections
+@using GridBlazorClientSide.Shared.Models
+@using Microsoft.Extensions.Primitives
+@using System.Globalization
+@using System.Threading.Tasks
+@inject NavigationManager NavigationManager
+@inject HttpClient HttpClient
+
+<h1>Rearrangeable Grid</h1>
+
+<p>
+    This page contains a grid with grid clomuns rearrange. Column titles can be dragged and dropped on each other to change order.
+</p>
+
+<p>
+    This component demonstrates a GridBlazor client-side grid. For more information, please see: <a href="https://github.com/gustavnavar/Grid.Blazor">https://github.com/gustavnavar/Grid.Blazor</a>
+</p>
+
+@if (_task.IsCompleted)
+{
+    <div class="row">
+        <div class="col-md-12">
+            <GridComponent T="Order" Grid="@_grid"></GridComponent>
+        </div>
+    </div>
+}
+else
+{
+    <p><em>Loading...</em></p>
+}
+
+@code
+{
+    private CGrid<Order> _grid;
+    private Task _task;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        var locale = CultureInfo.CurrentCulture;
+
+        var query = new QueryDictionary<StringValues>();
+        string url = NavigationManager.BaseUri + "api/SampleData/GetOrdersGridGroupable";
+        var client = new GridClient<Order>(HttpClient, url, query, false, "ordersGrid", 
+            ColumnCollections.OrderColumnsGroupable, locale)
+            .Sortable()
+            .Filterable()
+            .SetStriped(true)
+            .WithMultipleFilters()
+            .WithGridItemsCount()
+            .RearrangeableColumns(true);
+
+        _grid = client.Grid;
+        // Set new items to grid
+        _task = client.UpdateGrid();
+        await _task;
+    }
+}

--- a/GridBlazorClientSide.Client/Shared/NavMenu.razor
+++ b/GridBlazorClientSide.Client/Shared/NavMenu.razor
@@ -48,6 +48,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="rearrangeable">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Rearrangeable
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="editrows">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Edit rows
             </NavLink>


### PR DESCRIPTION
Hi

Added ability to reorder columns by drag and drop for Blazor grid.
Currently mouse has to be over column title text in order for drag over to properly detect dragging.
Svg icon taken from: https://icons.getbootstrap.com/icons/geo-fill/

This pr still can use of some polishing. But before making additional changes I wanted to get some feed back if this feature is still under consideration and in case it is some information if provided implementation fits overall project structure.  