### PR TITLE
Bug fix/no data on isnull filter

### DIFF
--- a/GridBlazor.Tests/Filtering/FilterTests.cs
+++ b/GridBlazor.Tests/Filtering/FilterTests.cs
@@ -362,6 +362,22 @@ namespace GridBlazor.Tests.Filtering
         }
 
         [TestMethod]
+        public void TestFilteringStringIsNotNull()
+        {
+            var firstItem = _repo.GetAll().First();
+            var settings = MockFilterSetting("Title", firstItem.Title, GridFilterType.IsNotNull);
+            TestFiltering(settings, x => x.Title, x => !string.IsNullOrEmpty(x.Title));
+        }
+
+        [TestMethod]
+        public void TestFilteringStringIsNull()
+        {
+            var firstItem = _repo.GetAll().First();
+            var settings = MockFilterSetting("Title", firstItem.Title, GridFilterType.IsNull);
+            TestFiltering(settings, x => x.Title, x => string.IsNullOrEmpty(x.Title));
+        }
+
+        [TestMethod]
         public void TestFilteringIntEquals()
         {
             var firstItem = _repo.GetAll().First();

--- a/GridBlazor.Tests/TestRepository.cs
+++ b/GridBlazor.Tests/TestRepository.cs
@@ -271,6 +271,32 @@ namespace GridBlazor.Tests
                             new TestModelChild { ChildTitle = "B19 - 3", ChildCreated = new DateTime(2002, 4, 10) }
                         }
                 };
+            yield return
+                new TestModel
+                {
+                    Id = 1,
+                    Title = "",
+                    Created = new DateTime(2002, 3, 2),
+                    Child = new TestModelChild { ChildTitle = "empty-title", ChildCreated = new DateTime(2002, 3, 5) },
+                    List = new TestModelChild[] {
+                            new TestModelChild { ChildTitle = "empty-title - 1", ChildCreated = new DateTime(2002, 2, 10) },
+                            new TestModelChild { ChildTitle = "empty-title - 2", ChildCreated = new DateTime(2002, 3, 10) },
+                            new TestModelChild { ChildTitle = "empty-title - 3", ChildCreated = new DateTime(2002, 4, 10) }
+                        }
+                };
+            yield return
+                new TestModel
+                {
+                    Id = 1,
+                    Title = null,
+                    Created = new DateTime(2002, 3, 2),
+                    Child = new TestModelChild { ChildTitle = "null-title", ChildCreated = new DateTime(2002, 3, 5) },
+                    List = new TestModelChild[] {
+                            new TestModelChild { ChildTitle = "null-title - 1", ChildCreated = new DateTime(2002, 2, 10) },
+                            new TestModelChild { ChildTitle = "null-title - 2", ChildCreated = new DateTime(2002, 3, 10) },
+                            new TestModelChild { ChildTitle = "null-title - 3", ChildCreated = new DateTime(2002, 4, 10) }
+                        }
+                };
         }
     }
 }

--- a/GridShared/Filtering/DefaultColumnFilter.cs
+++ b/GridShared/Filtering/DefaultColumnFilter.cs
@@ -107,15 +107,6 @@ namespace GridShared.Filtering
                 //get target type:
                 Type nestedTargetType = nestedIsNullable ? Nullable.GetUnderlyingType(nestedPi.PropertyType) : nestedPi.PropertyType;
 
-                // detects if an "is null" filter is applied on a string
-                //if (value.FilterType == GridFilterType.IsNull && targetType == typeof(string))
-                //{
-                //    /* 
-                //     * creates a "columname == null" expression 
-                //     * to also return data with a null value for the filtered column
-                //     */
-                //    binaryExpression = Expression.Equal(expression, Expression.Constant(null));
-                //}
                  if (nestedIsNullable || !nestedTargetType.IsValueType)
                 {
                     binaryExpression = binaryExpression == null ?
@@ -129,13 +120,8 @@ namespace GridShared.Filtering
             {
                 value.FilterValue = "";
                 if (targetType == typeof(string))
-                    /*
-                     * In case of a "is null" filter on a text column : 
-                     * Returns a filter that looks for items whose filtered column value is an empty string OR a null string
-                     * GetExpression(null, value, targetType, removeDiacritics) : returns a "<filteredcolumnname> == N''" expression
-                     * binaryExpression : already generated "<filteredcolumnname> == Null" expression
-                     */
-                    //return Expression.OrElse(GetExpression(null, value, targetType, removeDiacritics), binaryExpression);
+                    /* returns expression for IsNull, checking if the strings of a column
+                     * are null or empty */
                     return GetExpression(null, value, targetType, removeDiacritics);
                 else if (IsNullable)
                     return binaryExpression == null ?

--- a/GridShared/Filtering/DefaultColumnFilter.cs
+++ b/GridShared/Filtering/DefaultColumnFilter.cs
@@ -53,7 +53,6 @@ namespace GridShared.Filtering
         private Expression<Func<T, bool>> GetFilterExpression(IEnumerable<ColumnFilterValue> values,
             GridFilterCondition condition, MethodInfo removeDiacritics)
         {
-            var count = values.Count();
             Expression binaryExpression = null;
             foreach (var value in values)
             {

--- a/GridShared/Filtering/DefaultColumnFilter.cs
+++ b/GridShared/Filtering/DefaultColumnFilter.cs
@@ -107,7 +107,7 @@ namespace GridShared.Filtering
                 //get target type:
                 Type nestedTargetType = nestedIsNullable ? Nullable.GetUnderlyingType(nestedPi.PropertyType) : nestedPi.PropertyType;
 
-                 if (nestedIsNullable || !nestedTargetType.IsValueType)
+                if (nestedIsNullable || !nestedTargetType.IsValueType)
                 {
                     binaryExpression = binaryExpression == null ?
                         Expression.NotEqual(expression, Expression.Constant(null)) :
@@ -172,7 +172,7 @@ namespace GridShared.Filtering
             }
 
             binaryExpression = binaryExpression == null ? filterExpression :
-            Expression.AndAlso(binaryExpression, filterExpression);
+                Expression.AndAlso(binaryExpression, filterExpression);
 
             //return filter expression
             return binaryExpression;

--- a/GridShared/Filtering/DefaultColumnFilter.cs
+++ b/GridShared/Filtering/DefaultColumnFilter.cs
@@ -107,6 +107,8 @@ namespace GridShared.Filtering
                 //get target type:
                 Type nestedTargetType = nestedIsNullable ? Nullable.GetUnderlyingType(nestedPi.PropertyType) : nestedPi.PropertyType;
 
+                // Check for null on nested properties and not value type (string and objects are reference type)
+                // It's ok for ORM, but throw exception in linq to objects
                 if (nestedIsNullable || !nestedTargetType.IsValueType)
                 {
                     binaryExpression = binaryExpression == null ?

--- a/GridShared/Filtering/DefaultColumnFilter.cs
+++ b/GridShared/Filtering/DefaultColumnFilter.cs
@@ -108,15 +108,15 @@ namespace GridShared.Filtering
                 Type nestedTargetType = nestedIsNullable ? Nullable.GetUnderlyingType(nestedPi.PropertyType) : nestedPi.PropertyType;
 
                 // detects if an "is null" filter is applied on a string
-                if (value.FilterType == GridFilterType.IsNull && targetType == typeof(string))
-                {
-                    /* 
-                     * creates a "columname == null" expression 
-                     * to also return data with a null value for the filtered column
-                     */
-                    binaryExpression = Expression.Equal(expression, Expression.Constant(null));
-                }
-                else if (nestedIsNullable || !nestedTargetType.IsValueType)
+                //if (value.FilterType == GridFilterType.IsNull && targetType == typeof(string))
+                //{
+                //    /* 
+                //     * creates a "columname == null" expression 
+                //     * to also return data with a null value for the filtered column
+                //     */
+                //    binaryExpression = Expression.Equal(expression, Expression.Constant(null));
+                //}
+                 if (nestedIsNullable || !nestedTargetType.IsValueType)
                 {
                     binaryExpression = binaryExpression == null ?
                         Expression.NotEqual(expression, Expression.Constant(null)) :
@@ -135,7 +135,8 @@ namespace GridShared.Filtering
                      * GetExpression(null, value, targetType, removeDiacritics) : returns a "<filteredcolumnname> == N''" expression
                      * binaryExpression : already generated "<filteredcolumnname> == Null" expression
                      */
-                    return Expression.OrElse(GetExpression(null, value, targetType, removeDiacritics), binaryExpression);
+                    //return Expression.OrElse(GetExpression(null, value, targetType, removeDiacritics), binaryExpression);
+                    return GetExpression(null, value, targetType, removeDiacritics);
                 else if (IsNullable)
                     return binaryExpression == null ?
                         Expression.Equal(_expression.Body, Expression.Constant(null)) :

--- a/GridShared/Filtering/Types/TextFilterType.cs
+++ b/GridShared/Filtering/Types/TextFilterType.cs
@@ -54,7 +54,7 @@ namespace GridShared.Filtering.Types
                     binaryExpression = GetCaseInsensitiveСomparation(string.Empty, leftExpr, valueExpr, removeDiacritics);
                     break;
                 case GridFilterType.IsNull:
-                    binaryExpression = GetNullOrEmptyComparation(leftExpr);
+                    binaryExpression = GetNullOrEmptyCheck(leftExpr);
                     break;
                 case GridFilterType.NotEquals:
                 case GridFilterType.IsNotNull:
@@ -75,9 +75,14 @@ namespace GridShared.Filtering.Types
             return binaryExpression;
         }
 
-        private Expression GetNullOrEmptyComparation(Expression leftExpr)
+        private Expression GetNullOrEmptyCheck(Expression paramExpr)
         {
-            MethodCallExpression isNullOrEmptyStringExpr = Expression.Call(typeof(string), "IsNullOrEmpty", null, leftExpr);
+            /* 
+            * Returns an expression calling string.IsNullOrEmpty on the column we want to filter
+            * EF will automatically generate sql from this expression to check 
+            * if the value for the filtered column is null or empty
+            */
+            MethodCallExpression isNullOrEmptyStringExpr = Expression.Call(typeof(string), "IsNullOrEmpty", null, paramExpr);
             return isNullOrEmptyStringExpr;
         }
 

--- a/GridShared/Filtering/Types/TextFilterType.cs
+++ b/GridShared/Filtering/Types/TextFilterType.cs
@@ -115,7 +115,6 @@ namespace GridShared.Filtering.Types
                     return Expression.Call(upperFirstExpr, mi, upperValueExpr);
                 }
             }
-            var exp = Expression.Equal(upperFirstExpr, upperValueExpr);
             return Expression.Equal(upperFirstExpr, upperValueExpr);
         }
 

--- a/GridShared/Filtering/Types/TextFilterType.cs
+++ b/GridShared/Filtering/Types/TextFilterType.cs
@@ -51,9 +51,10 @@ namespace GridShared.Filtering.Types
             switch (filterType)
             {
                 case GridFilterType.Equals:
+                    binaryExpression = GetCaseInsensitiveСomparation(string.Empty, leftExpr, valueExpr, removeDiacritics);
+                    break;
                 case GridFilterType.IsNull:
                     binaryExpression = GetNullOrEmptyComparation(leftExpr);
-                    //binaryExpression = GetCaseInsensitiveСomparation(string.Empty, leftExpr, valueExpr, removeDiacritics);
                     break;
                 case GridFilterType.NotEquals:
                 case GridFilterType.IsNotNull:
@@ -76,9 +77,8 @@ namespace GridShared.Filtering.Types
 
         private Expression GetNullOrEmptyComparation(Expression leftExpr)
         {
-            Type targetType = TargetType;
-            MethodCallExpression upperValueExpr = Expression.Call(typeof(string), "IsNullOrEmpty", null, leftExpr);
-            return upperValueExpr;
+            MethodCallExpression isNullOrEmptyStringExpr = Expression.Call(typeof(string), "IsNullOrEmpty", null, leftExpr);
+            return isNullOrEmptyStringExpr;
         }
 
         private Expression GetCaseInsensitiveСomparation(string methodName, Expression leftExpr, Expression rightExpr,

--- a/GridShared/Filtering/Types/TextFilterType.cs
+++ b/GridShared/Filtering/Types/TextFilterType.cs
@@ -52,7 +52,8 @@ namespace GridShared.Filtering.Types
             {
                 case GridFilterType.Equals:
                 case GridFilterType.IsNull:
-                    binaryExpression = GetCaseInsensitiveСomparation(string.Empty, leftExpr, valueExpr, removeDiacritics);
+                    binaryExpression = GetNullOrEmptyComparation(leftExpr);
+                    //binaryExpression = GetCaseInsensitiveСomparation(string.Empty, leftExpr, valueExpr, removeDiacritics);
                     break;
                 case GridFilterType.NotEquals:
                 case GridFilterType.IsNotNull:
@@ -71,6 +72,13 @@ namespace GridShared.Filtering.Types
                     throw new ArgumentOutOfRangeException();
             }
             return binaryExpression;
+        }
+
+        private Expression GetNullOrEmptyComparation(Expression leftExpr)
+        {
+            Type targetType = TargetType;
+            MethodCallExpression upperValueExpr = Expression.Call(typeof(string), "IsNullOrEmpty", null, leftExpr);
+            return upperValueExpr;
         }
 
         private Expression GetCaseInsensitiveСomparation(string methodName, Expression leftExpr, Expression rightExpr,
@@ -102,6 +110,7 @@ namespace GridShared.Filtering.Types
                     return Expression.Call(upperFirstExpr, mi, upperValueExpr);
                 }
             }
+            var exp = Expression.Equal(upperFirstExpr, upperValueExpr);
             return Expression.Equal(upperFirstExpr, upperValueExpr);
         }
 


### PR DESCRIPTION
 Content of the PR
This pr is a proposed solution for the bug explained in issue #381.
# Explanation of the fixed bug

There was a problem in the way IsNull filters for text columns were generated by the `DefaultColumnFilter` class. 

For example, when applying an "IsNull" filter on a column named "shipRegion", the expression generated for the filter was as follows :

```csharp
e.shipRegion != null && e.shipRegion.ToUpper() == "".ToUpper()
```

This expression only includes data whose value for the filtered column is an empty string, and not a null string. This is a problem as we are trying to filter data whose value for this column is null.

# Changes applied

In order to fixed this problem, I had to edit `DefaultColumnFilter` and `TextFilterType` files to change the way IsNull filters on text column are generated.

## Changes on `TextFilterType`

In this class I added the `GetNullOrEmptyCheck(Expression paramExpr)` method which returns an expression calling string.IsNullOrEmpty on the filtered column. When querying the database, EF will translate this expression to this sql condition: 

```sql
WHERE ([o].[ShipRegion] IS NULL) OR ([o].[ShipRegion] LIKE N'')
```

Including both data whose value for the filtered column is a null string or an empty string.

I then called this method in `GetFilterExpression`'s switch, instead of `GetCaseInsensitiveСomparation`.

```csharp
switch (filterType)
    {
        case GridFilterType.Equals:
            binaryExpression = GetCaseInsensitiveСomparation(string.Empty, leftExpr, valueExpr, removeDiacritics);
            break;
        case GridFilterType.IsNull:
            binaryExpression = GetNullOrEmptyCheck(leftExpr);
            break;
```

## Changes on `DefaultColumnFilter`

I then changed the way `GetExpression` was called in the case of an IsNull filter on a string column (line 124), so that it only returns the expression generated by the `GetNullOrEmptyCheck` method, and not an expression of the type :

```csharp
e.shipRegion != null && (string.IsNullOrEmpty(e.shipRegion))
```

Which would not make sense.
