### PR TITLE
Changed hard coded label, for current page, to editable

### DIFF
--- a/GridBlazor/Client/GridClient.cs
+++ b/GridBlazor/Client/GridClient.cs
@@ -159,6 +159,12 @@ namespace GridBlazor
             return this;
         }
 
+        public IGridClient<T> SetLabelForCurrentPage(string label)
+        {
+            _source.Pager.CurrentPageLabel = label;
+            return this;
+        }
+
         public IGridClient<T> GoToVisibility(bool enable)
         {
             _source.Pager.GoToVisibility = enable;

--- a/GridBlazor/Client/IGridClient.cs
+++ b/GridBlazor/Client/IGridClient.cs
@@ -43,6 +43,13 @@ namespace GridBlazor
         IGridClient<T> WithPaging(int pageSize, int maxDisplayedItems, string queryStringParameterName);
 
         /// <summary>
+        ///     Sets the label that indicates the current page to the user
+        /// </summary>
+        /// <param name="label">Text for the label</param>
+        /// <returns></returns>
+        IGridClient<T> SetLabelForCurrentPage(string label);
+
+        /// <summary>
         ///     Enable go to pager visibility
         /// </summary>
         /// <param name="enable">Enable go to pager visibility</param>

--- a/GridBlazor/Pages/GridPagerComponent.razor
+++ b/GridBlazor/Pages/GridPagerComponent.razor
@@ -30,7 +30,7 @@
                     if (i == GridComponent.Grid.Pager.CurrentPage)
                     {
                         <li class="page-item active">
-                            <button type="button" class="page-link">@i <span class="sr-only">(current)</span></button>
+                            <button type="button" class="page-link">@i <span class="sr-only">@GridComponent.Grid.Pager.CurrentPageLabel</span></button>
                         </li>
                     }
                     else

--- a/GridBlazor/Pagination/GridPager.cs
+++ b/GridBlazor/Pagination/GridPager.cs
@@ -214,6 +214,11 @@ namespace GridBlazor.Pagination
                                    : _currentPage + MaxDisplayedPages/2;
         }
 
+        /// <summary>
+        ///     Label to show which page the user currently is on
+        /// </summary>
+        public string CurrentPageLabel { get; set; } = "(current)";
+
         #region View
 
         public int StartDisplayedPage { get; protected set; }

--- a/GridBlazor/Pagination/IGridPager.cs
+++ b/GridBlazor/Pagination/IGridPager.cs
@@ -71,5 +71,10 @@ namespace GridBlazor.Pagination
         ///// <param name="pageIndex">Номер страницы</param>
         ///// <returns>Адрес страницы</returns>
         //string GetLinkForPage(int pageIndex);
+
+        /// <summary>
+        ///     Label to show which page the user currently is on
+        /// </summary>
+        string CurrentPageLabel { get; set; }
     }
 }


### PR DESCRIPTION
The label (in GridPagerComponent.razor) was hard coded to "(current)". This has been changed, such that it can be set via the method SetLabelForCurrentPage.